### PR TITLE
Fix missing assignment in clean_track_name

### DIFF
--- a/InfoFileTagger.py
+++ b/InfoFileTagger.py
@@ -107,7 +107,7 @@ def clean_track_name(title):
     """
 
     original = title
-    strip_after_n_spaces(title,5)
+    title = strip_after_n_spaces(title,5)
     #get rid of oddball whitespace
     re.sub(r'[\t\n\r\f\v]+', ' ', title)
     #trim all spaces down to 1


### PR DESCRIPTION
## Summary
- assign result of `strip_after_n_spaces` back to `title` in `clean_track_name`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869573a453c832c9f5a0e0a9d658c40