### PR TITLE
Fix csv dump path and f‑string errors

### DIFF
--- a/sqliteetreedb.py
+++ b/sqliteetreedb.py
@@ -829,7 +829,7 @@ class SQLiteEtreeDB:
 
 
 
-    def dump_sqlite_to_csv(self, folder='db/extract'):
+    def dump_sqlite_to_csv(self, folder='db/extract', db_path=None):
         """
         Dumps all tables from the given SQLite database to CSV files.
         Each CSV file is named after its table (e.g., 'table_name.csv') and
@@ -837,13 +837,17 @@ class SQLiteEtreeDB:
         saved into a specified folder (absolute or relative path).
 
         Args:
-            db_path (str): Path to the SQLite database file.
             folder (str, optional): Directory where CSV files will be saved.
                                     If provided, the folder will be created if it doesn't exist.
+            db_path (str, optional): Path to the SQLite database file.
+                                     Defaults to the path used by this instance.
         """
         # If a folder is provided, ensure it exists
         if folder:
             os.makedirs(folder, exist_ok=True)
+
+        if db_path is None:
+            db_path = self.db_path
 
         # Connect to the SQLite database
         conn = sqlite3.connect(db_path)
@@ -960,13 +964,16 @@ class EtreeRecording:
 
     def build_info_file(self):
         #TODO: add gazinta substitution here, use config file for title format
-        print (f"Artist: {self.artist}")
-        print (f'Album: {self.date} {self.etreevenue} {'['+self.tracks[0].bitabbrev+']' if self.tracks[0].bitabbrev else ''} {'('+str(self.id)+')'}')
-            
-        print (f'Comment: {self.source}')
+        print(f"Artist: {self.artist}")
+        bit = f"[{self.tracks[0].bitabbrev}]" if self.tracks and self.tracks[0].bitabbrev else ""
+        print(f"Album: {self.date} {self.etreevenue} {bit} ({self.id})")
+
+        print(f"Comment: {self.source}")
         for track in self.tracks:
-            print(f"{'d'+track.disc.split('/')[0] if track.disc else ''}{'t'+track.tracknum.split('/')[0] +
-                                                                         '. ' if track.tracknum else ''}{track.title_clean}{' ->' if track.gazinta == 'T' else ''} [{track.length}]")
+            disc_str = f"d{track.disc.split('/')[0]}" if track.disc else ""
+            track_str = f"t{track.tracknum.split('/')[0]}. " if track.tracknum else ""
+            arrow = " ->" if track.gazinta == 'T' else ""
+            print(f"{disc_str}{track_str}{track.title_clean}{arrow} [{track.length}]")
 
 class Track:
     def __init__(self,shnid, disc_number, track_number, title, fingerprint, bit_depth, frequency, length, channels, filename, md5key,title_clean,gazinta):

--- a/tagger.py
+++ b/tagger.py
@@ -482,9 +482,19 @@ class ConcertTagger:
         ####DEPRECATED####
         #TODO customise this string (separate function?)
         #print(f'{self.etreerec.date=}')
-        album = f'{self.etreerec.date} {self.etreerec.etreevenue} {'('+self.folder.recordingtype+') ' if self.folder.recordingtype else ''}{'['+str(self.folder.musicfiles[0].audio.info.bits_per_sample)+'-'+
-                                                                   str(self.folder.musicfiles[0].audio.info.sample_rate).rstrip('0')+
-                                                                   '] ' if self.folder.musicfiles and str(self.folder.musicfiles[0].audio.info.bits_per_sample) != '16' else ''}{'('+str(self.etreerec.id)+')'}'
+        album = f"{self.etreerec.date} {self.etreerec.etreevenue} "
+        if self.folder.recordingtype:
+            album += f"({self.folder.recordingtype}) "
+        if (
+            self.folder.musicfiles
+            and str(self.folder.musicfiles[0].audio.info.bits_per_sample) != "16"
+        ):
+            bitrate = (
+                f"{self.folder.musicfiles[0].audio.info.bits_per_sample}-"
+                f"{str(self.folder.musicfiles[0].audio.info.sample_rate).rstrip('0')}"
+            )
+            album += f"[{bitrate}] "
+        album += f"({self.etreerec.id})"
         print(f'{album=}')
         if not self.etreerec.tracks:
             print(f'ERROR: Unable to tag track names. No Metadata found in {self.db.db_path} for {self.folderpath.as_posix()}')
@@ -712,7 +722,10 @@ class ConcertTagger:
             #print(file.name, self.etreerec.id, [track.title for track in self.etreerec.tracks if track.fingerprint == file.checksum][0])
             tracknum, disc, title = None, None, None
             if song_info:
-                tracknum, disc, title = song_info.tracknum, song_info.disc,f'{song_info.title}{' ' + gazinta_abbrev if song_info.gazinta else ''}'
+                title = song_info.title
+                if song_info.gazinta:
+                    title = f"{title} {gazinta_abbrev}"
+                tracknum, disc = song_info.tracknum, song_info.disc
             args_list.append((file.path, file.name, artwork_path_str, clear_existing_artwork, clear_existing_tags,
              album, genretag, self.etreerec.artist, self.etreerec.source,tracknum, disc, title))
             #print(song_info.title, song_info.gazinta)


### PR DESCRIPTION
## Summary
- fix `dump_sqlite_to_csv` to use the database path from the instance when none is specified
- refactor `build_info_file` to avoid malformed f-strings
- clean up deprecated `tag_album` string building
- correct title construction when adding tags

## Testing
- `python -m py_compile sqliteetreedb.py`
- `python -m py_compile InfoFileTagger.py`
- `python -m py_compile tagger.py`
- `python -m py_compile recordingfiles.py`
- `python -m py_compile import_show_metadata.py`

------
https://chatgpt.com/codex/tasks/task_e_686945a237a8832c9c233369db327f29