### PR TITLE
Improve RecordingFolder companion file detection

### DIFF
--- a/recordingfiles.py
+++ b/recordingfiles.py
@@ -21,9 +21,15 @@ class RecordingFolder:
             raise ValueError(f"{concert_folder} is not a valid directory.")
         self.foldershnid = self._parse_shnid(self.folder.name)
         self.musicfiles =  [MusicFile(str(x)) for x in self.folder.glob("*.flac")]
-        self.text_files = self.folder.glob("*.txt")
-        self.fingerprint_files = self.folder.glob("*.ffp")
-        self.st5_files = self.folder.glob("*.st5")
+
+        # identify optional companion files
+        self.info_file = (
+            self._find_file_by_keyword("txt", "info")
+            or self._find_file_by_extension("txt")
+        )
+        self.fingerprint_file = self._find_file_by_extension("ffp")
+        self.st5_file = self._find_file_by_extension("st5")
+        self.artwork_file = self._find_artwork()
         self.checksums = self._get_checksums(self.musicfiles)
         self.recordingtype = self._classify_folder(self.folder.name)
 

--- a/tests/test_recordingfiles.py
+++ b/tests/test_recordingfiles.py
@@ -1,0 +1,52 @@
+import types
+import sys
+from pathlib import Path
+
+# ensure project root is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide a minimal stub for the mutagen.flac module used by recordingfiles
+mutagen = types.ModuleType('mutagen')
+flac_mod = types.ModuleType('mutagen.flac')
+class DummyInfo:
+    length = 0
+    md5_signature = b''
+    bits_per_sample = 16
+    sample_rate = 44100
+    channels = 2
+class DummyFLAC:
+    def __init__(self, path):
+        self.info = DummyInfo()
+    def __contains__(self, item):
+        return False
+    def __getitem__(self, item):
+        raise KeyError
+flac_mod.FLAC = DummyFLAC
+flac_mod.Picture = object
+mutagen.flac = flac_mod
+sys.modules.setdefault('mutagen', mutagen)
+sys.modules.setdefault('mutagen.flac', flac_mod)
+
+from recordingfiles import RecordingFolder
+
+
+def _create_sample_files(base: Path, info_name='info.txt'):
+    (base / info_name).write_text('info contents', encoding='utf-8')
+    (base / 'example.ffp').write_text('fingerprint data', encoding='utf-8')
+    (base / 'checks.st5').write_text('checksum data', encoding='utf-8')
+
+
+def test_read_methods_with_info_keyword(tmp_path: Path):
+    _create_sample_files(tmp_path)
+    rec = RecordingFolder(str(tmp_path))
+    assert rec.read_info() == 'info contents'
+    assert rec.read_fingerprint() == 'fingerprint data'
+    assert rec.read_checksums() == 'checksum data'
+
+
+def test_fallback_txt_detection(tmp_path: Path):
+    _create_sample_files(tmp_path, info_name='notes.txt')
+    rec = RecordingFolder(str(tmp_path))
+    # Should fall back to the only txt file
+    assert rec.info_file.name == 'notes.txt'
+    assert rec.read_info() == 'info contents'


### PR DESCRIPTION
## Summary
- refine `RecordingFolder.__init__` to store info, fingerprint, checksum and artwork file paths
- remove unused file glob attributes
- provide tests for `read_info`, `read_fingerprint` and `read_checksums`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68695c3424b8832cae650f6ab5e56bda