### PR TITLE
Add utils tests and config tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ soundboard_abbrev = "SBD"
 aud_abbrev = "AUD"
 matrix_abbrev = "MTX"
 ultramatrix_abbrev = "Ultramatrix"
+verbose_logging = false
 [album_tag]
 include_bitrate = true
 include_bitrate_not16_only = true

--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,7 @@ soundboard_abbrev = "SBD"
 aud_abbrev = "AUD"
 matrix_abbrev = "MTX"
 ultramatrix_abbrev = "Ultramatrix"
+verbose_logging = false
 [album_tag]
 # Toggle inclusion of optional components in the album tag.
 include_bitrate = true

--- a/tests/test_infofiletagger_utils.py
+++ b/tests/test_infofiletagger_utils.py
@@ -1,0 +1,55 @@
+import types
+import sys
+from pathlib import Path
+
+# ensure project root is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide a minimal stub for the mutagen.flac module used by InfoFileTagger
+mutagen = types.ModuleType('mutagen')
+flac_mod = types.ModuleType('mutagen.flac')
+flac_mod.FLAC = object
+flac_mod.Picture = object
+mutagen.flac = flac_mod
+sys.modules.setdefault('mutagen', mutagen)
+sys.modules.setdefault('mutagen.flac', flac_mod)
+
+from InfoFileTagger import (
+    is_valid_date,
+    file_sort_key,
+    strip_after_n_spaces,
+    clean_track_name,
+)
+
+
+def test_is_valid_date_true():
+    assert is_valid_date("2025-07-05")
+    assert is_valid_date("07-05-25")
+    assert is_valid_date("07/05/2025")
+
+
+def test_is_valid_date_false():
+    assert not is_valid_date("not a date")
+    assert not is_valid_date("2025-13-01")
+
+
+def test_file_sort_key_parsing():
+    assert file_sort_key("foo/d1t02.flac") == (1, 2)
+    assert file_sort_key("bar/s3t10.wav") == (3, 10)
+
+
+def test_file_sort_key_fallback():
+    disc, track = file_sort_key("foo/bar.flac")
+    assert disc == float("inf")
+    assert track == "bar"
+
+
+def test_strip_after_n_spaces():
+    assert strip_after_n_spaces("hello     world", 5) == "hello"
+    assert strip_after_n_spaces("hello   world", 5) == "hello   world"
+
+
+def test_clean_track_name_basic():
+    assert clean_track_name("e: Dark Star") == "Dark Star"
+    assert clean_track_name("Drums->Space") == "Drums > Space"
+    assert clean_track_name("Encore: Ripple") == "Ripple"


### PR DESCRIPTION
## Summary
- add test_infofiletagger_utils for helper functions
- tweak config to include a `verbose_logging` preference
- document the new setting in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68695e962e28832c959bcea436678b45