### PR TITLE
Support partial dates; fix config artwork path

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ suffix = ['','','','',')',']']
 [cover]
 clear_existing_artwork = false # Clears existing artwork tags and sets a new one
 retain_existing_artwork = true
+defaultimage_path = 'GD_Art/default.jpg'
 
 [cover.artwork_folders]
 gd = ['GD_Art/EE_Artwork/', 'GD_Art/TV_Artwork/']
-
-defaultimage_path = 'GD_Art/default.jpg'
 ```
 ## License
 

--- a/config.toml
+++ b/config.toml
@@ -39,14 +39,12 @@ suffix = ['','','','',')',']']
 [cover]
 clear_existing_artwork = false # Clears existing artwork tags and sets a new one
 retain_existing_artwork = true # If an existing folder.{ext} file exists, append its name w/".old", even if the tag is overwritten
+defaultimage_path = 'GD_Art/default.jpg'
 
 [cover.artwork_folders]
 gd = ['GD_Art/EE_Artwork/', 'GD_Art/TV_Artwork/']
 # Add additional entries keyed by artist abbreviation.
 # If an abbreviation is missing, tagging will continue without artwork.
-
-#this image will be used if no image is found for the given date in the paths above
-defaultimage_path = 'GD_Art/default.jpg'
 
 
 

--- a/tagger.py
+++ b/tagger.py
@@ -75,8 +75,13 @@ def extract_year(date_str):
         valid_date = datetime.strptime(date_str, "%Y-%m-%d")
         return valid_date.year
     except ValueError:
-        # If it fails, fall back to extracting a two-digit year.
+        # If it fails, continue with more flexible parsing.
         pass
+
+    # Look for any four digit year in the string.
+    match = re.search(r"(\d{4})", date_str)
+    if match:
+        return int(match.group(1))
 
     # Look for a two-digit year pattern at the end of the string.
     match = re.search(r'(\d{2})$', date_str)

--- a/tests/test_extract_year.py
+++ b/tests/test_extract_year.py
@@ -1,0 +1,32 @@
+import sys
+import types
+from pathlib import Path
+
+# ensure project root is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide a minimal stub for the mutagen.flac module used by tagger
+mutagen = types.ModuleType('mutagen')
+flac_mod = types.ModuleType('mutagen.flac')
+flac_mod.FLAC = object
+flac_mod.Picture = object
+mutagen.flac = flac_mod
+sys.modules.setdefault('mutagen', mutagen)
+sys.modules.setdefault('mutagen.flac', flac_mod)
+tqdm_mod = types.ModuleType('tqdm')
+tqdm_mod.tqdm = lambda x=None, **k: x
+sys.modules.setdefault('tqdm', tqdm_mod)
+
+from tagger import extract_year
+
+
+def test_extract_year_iso():
+    assert extract_year("1975-06-21") == 1975
+
+
+def test_extract_year_partial_dashes():
+    assert extract_year("1975-XX-XX") == 1975
+
+
+def test_extract_year_partial_question():
+    assert extract_year("??/??/75") == 1975


### PR DESCRIPTION
## Summary
- recognize four-digit years in `extract_year`
- move `defaultimage_path` to the correct section of `config.toml`
- update README snippet
- add regression tests for `extract_year`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869b1dbc928832ca159694ba7d290c6