### PR TITLE
Support artist-specific default artwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ suffix = ['','','','',')',']']
 [cover]
 clear_existing_artwork = false # Clears existing artwork tags and sets a new one
 retain_existing_artwork = true
-defaultimage_path = 'GD_Art/default.jpg'
+
+[cover.default_images]
+# Map artist abbreviations to fallback artwork.
+gd = 'GD_Art/default.jpg'
 
 [cover.artwork_folders]
 gd = ['GD_Art/EE_Artwork/', 'GD_Art/TV_Artwork/']

--- a/config.toml
+++ b/config.toml
@@ -39,12 +39,15 @@ suffix = ['','','','',')',']']
 [cover]
 clear_existing_artwork = false # Clears existing artwork tags and sets a new one
 retain_existing_artwork = true # If an existing folder.{ext} file exists, append its name w/".old", even if the tag is overwritten
-defaultimage_path = 'GD_Art/default.jpg'
+
+[cover.default_images]
+# Map artist abbreviations to fallback artwork.
+gd = 'GD_Art/default.jpg'
 
 [cover.artwork_folders]
 gd = ['GD_Art/EE_Artwork/', 'GD_Art/TV_Artwork/']
 # Add additional entries keyed by artist abbreviation.
-# If an abbreviation is missing, tagging will continue without artwork.
+# If an abbreviation is missing, artwork tagging is skipped for that artist.
 
 
 

--- a/tests/test_find_artwork.py
+++ b/tests/test_find_artwork.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+import pytest
+
+# ensure project root is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tagger import ConcertTagger
+
+
+def _make_tagger(folders, defaults):
+    tagger = ConcertTagger.__new__(ConcertTagger)
+    tagger.artwork_folders = folders
+    tagger.default_images_map = defaults
+    return tagger
+
+
+def test_find_artwork_from_folder(tmp_path: Path):
+    art_dir = tmp_path / "art" / "1975"
+    art_dir.mkdir(parents=True)
+    art_file = art_dir / "gd1975-03-23.jpg"
+    art_file.write_text("dummy")
+
+    tagger = _make_tagger([str(tmp_path / "art")], {"gd": str(tmp_path / "default.jpg")})
+    result = tagger._find_artwork("gd", "1975-03-23")
+    assert result == art_file
+
+
+def test_find_artwork_default(tmp_path: Path):
+    default = tmp_path / "default.jpg"
+    default.write_text("img")
+    tagger = _make_tagger([str(tmp_path / "art")], {"gd": str(default)})
+    result = tagger._find_artwork("gd", "1975-03-23")
+    assert result == default
+
+
+def test_find_artwork_missing_default(tmp_path: Path):
+    tagger = _make_tagger([str(tmp_path / "art")], {"gd": str(tmp_path / "default.jpg")})
+    with pytest.raises(FileNotFoundError):
+        tagger._find_artwork("gd", "1975-03-23")
+
+
+def test_find_artwork_no_default(tmp_path: Path):
+    tagger = _make_tagger([str(tmp_path / "art")], {})
+    result = tagger._find_artwork("gd", "1975-03-23")
+    assert result is None
+


### PR DESCRIPTION
## Summary
- allow configuring fallback artwork per artist via `[cover.default_images]`
- raise errors when artwork should be tagged but no image can be located
- update docs for new option
- test `_find_artwork` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869b753d70c832cb3a8ba7b8e371b1a