### PR TITLE
Fix extraction when archives contain directory entries

### DIFF
--- a/compression_utils.py
+++ b/compression_utils.py
@@ -30,10 +30,18 @@ def _root_folder_if_single(names: list[str]) -> str | None:
             continue
         parts = Path(name).parts
         if len(parts) == 1:
-            return None  # file at root level
+            # A single path component could be a directory entry in the
+            # archive (e.g. ``folder/``). When the entry does not end with a
+            # path separator it's a file at the archive root, which means
+            # there's no single parent folder.
+            if not name.endswith(('/', '\\')):
+                return None
+            candidate = parts[0]
+        else:
+            candidate = parts[0]
         if root is None:
-            root = parts[0]
-        elif root != parts[0]:
+            root = candidate
+        elif root != candidate:
             return None
     return root
 

--- a/tests/test_compression_utils.py
+++ b/tests/test_compression_utils.py
@@ -53,3 +53,19 @@ def test_overwrite(tmp_path: Path):
 
     extract_archives(zdir, target=dest, overwrite=True)
     assert (dest / "folder" / "file.txt").read_text() == "new"
+
+
+def test_zip_with_directory_entry(tmp_path: Path):
+    """Zip files may contain an explicit folder entry."""
+    zdir = tmp_path / "z"
+    zdir.mkdir()
+    zip_path = zdir / "f.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("folder/", "")
+        zf.writestr("folder/a.txt", "A")
+        zf.writestr("folder/b.txt", "B")
+
+    extract_archives(zdir)
+
+    assert (zdir / "folder" / "a.txt").read_text() == "A"
+    assert (zdir / "folder" / "b.txt").read_text() == "B"


### PR DESCRIPTION
## Summary
- handle directory entries when detecting a single root folder
- add regression test for zip files that include a folder entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be2cbdbc4832ca0c53112d69d93bb