### PR TITLE
Fix handling of trailing spaces in archive folders

### DIFF
--- a/compression_utils.py
+++ b/compression_utils.py
@@ -15,8 +15,14 @@ except Exception:  # pragma: no cover - rarfile is optional
 
 
 def _normalize(name: str) -> Path:
-    """Return ``Path`` for ``name`` using ``/`` as separator."""
-    return Path(name.replace("\\", "/"))
+    """Return ``Path`` for ``name`` using ``/`` as separator.
+
+    Trailing spaces in each path component are stripped to avoid issues with
+    archives that contain folders with a trailing space in the name.
+    """
+    name = name.replace("\\", "/")
+    cleaned = "/".join(part.rstrip() for part in name.split("/"))
+    return Path(cleaned)
 
 
 def _is_hidden(name: str) -> bool:

--- a/tests/test_compression_utils.py
+++ b/tests/test_compression_utils.py
@@ -94,3 +94,17 @@ def test_root_with_backslashes(tmp_path: Path):
     extract_archives(zdir, target=out)
 
     assert (out / "root" / "a.txt").read_text() == "A"
+
+
+def test_trailing_space_in_folder_name(tmp_path: Path):
+    """Folder names ending with spaces should be normalized."""
+    zdir = tmp_path / "z"
+    zdir.mkdir()
+    zip_path = zdir / "space.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("folder /", "")
+        zf.writestr("folder /file.txt", "X")
+
+    extract_archives(zdir)
+
+    assert (zdir / "folder" / "file.txt").read_text() == "X"


### PR DESCRIPTION
## Summary
- normalize archive paths by stripping trailing spaces in every path component
- add regression test for folders ending with a space

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759f321a94832cab14048732918911