### PR TITLE
Fix zip extraction with quoted filenames

### DIFF
--- a/compression_utils.py
+++ b/compression_utils.py
@@ -17,11 +17,16 @@ except Exception:  # pragma: no cover - rarfile is optional
 def _normalize(name: str) -> Path:
     """Return ``Path`` for ``name`` using ``/`` as separator.
 
-    Trailing spaces in each path component are stripped to avoid issues with
-    archives that contain folders with a trailing space in the name.
+    Trailing spaces and any double quotes in each path component are stripped to
+    avoid issues with archives that contain problematic characters in the
+    entries.
     """
     name = name.replace("\\", "/")
-    cleaned = "/".join(part.rstrip() for part in name.split("/"))
+    cleaned_parts = []
+    for part in name.split("/"):
+        part = part.rstrip().replace('"', "")
+        cleaned_parts.append(part)
+    cleaned = "/".join(cleaned_parts)
     return Path(cleaned)
 
 

--- a/tests/test_compression_utils.py
+++ b/tests/test_compression_utils.py
@@ -108,3 +108,16 @@ def test_trailing_space_in_folder_name(tmp_path: Path):
     extract_archives(zdir)
 
     assert (zdir / "folder" / "file.txt").read_text() == "X"
+
+
+def test_quotes_in_file_name(tmp_path: Path):
+    """Double quotes in file names should be stripped."""
+    zdir = tmp_path / "z"
+    zdir.mkdir()
+    zip_path = zdir / "quote.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr('folder/"a".txt', "Q")
+
+    extract_archives(zdir)
+
+    assert (zdir / "folder" / "a.txt").read_text() == "Q"


### PR DESCRIPTION
## Summary
- revert unintended losslessfiles change
- strip double quotes when normalizing archive member paths
- test extraction of archives containing quoted filenames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875a1dc0230832ca8c6e385d92b9f7b